### PR TITLE
Update meta.json

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "viam:python-container-example",
+  "module_id": "viam:python-container-example",
   "visibility": "public",
   "url": "https://github.com/viam-labs/python-container-module",
   "description": "Example of deploying a python module with docker",


### PR DESCRIPTION


Name has been deprecated in favor of module_id and will no longer work with the newest versions of the cli
